### PR TITLE
feat: Allow custom shell name to be manually specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ echo 'xontrib load sh' >> ~/.xonshrc
 
 ## Usage
 
-Start the line with `! ` (exclamation point with space) then paste the sh-compatible commands after it and run. 
+There are two ways to invoke an sh-compatible command:
+
+####1. With a shell detected automatically
+
+Start the line with 
+
+`!` ` ` (exclamation mark with space)
+
+then paste the sh-compatible commands after it and run. 
 The commands syntax will be tested in the shells from list (if installed) and the commands will be run in 
 the first matching shell. By default list of shells contains bash and sh. 
 
@@ -27,6 +35,25 @@ To set the list of shells use environment variable before loading the xontrib:
 ```python
 $XONTRIB_SH_SHELLS = ['bash', 'sh']  # default
 xontrib load sh
+```
+
+####2. With a shell specified manually
+
+Same as above, but add the required shell name between the exclamation mark and space, either:
+
+`!bash` ` ` the full shell name OR
+
+`!b` ` ` only its first letter
+
+then paste sh-compatible commands after it and run.
+
+Each shell name (or only its first letter, or both, depending on the value of the two environment variables listed below) from the configured list will be matched against the full/short name specified in the prefix, and the commands will be run in the first matching shell (if installed).
+
+```python
+# Given '!b ', match 'b' to the first letter of each shell in $XONTRIB_SH_SHELLS (use the first shell starting with 'b')
+$XONTRIB_SH_USEFIRST = True # default True
+# Given '!bash ', match 'bash' to the full name of each shell in $XONTRIB_SH_SHELLS
+$XONTRIB_SH_USEFULL  = True # default True
 ```
 
 ## The main use case
@@ -40,13 +67,17 @@ TMP=/tmp && cd $TMP && ( [[ -x $(command -v curl) ]] && echo "Yes" || echo "No" 
 ```
 
 You hesitate how xonsh will execute this and you're absolutely right there will be syntax error. 
-To run this just start with `! ` and paste the commands. As result you'll see the right message.
+To run this just start with `! ` or `!b ` or `!bash ` and paste the commands. As result you'll see the right message.
 
 ## Examples
 
 ### Bash brace expansion
 ```bash
 ! echo 01.{05..10}
+    #OR
+!b echo 01.{05..10}    # unless $XONTRIB_SH_MATCHFIRST = False (default is True)
+    #OR
+!bash echo 01.{05..10} # unless $XONTRIB_SH_MATCHFULL  = False (default is True)
 ``` 
 ```
 bash:
@@ -92,6 +123,12 @@ xontrib load sh
 # Run fish command:
 ! set -U EDITOR vim
 # bash: line 0: set: -U: invalid option
+```
+However, the command with the fish shell __specified explicitly__ will succeed
+```python
+# Run fish command in a manually set fish shell
+# requires option '$XONTRIB_SH_MATCHFULL = True', which is the default value
+!fish set -U EDITOR vim
 ```
 
 Use shells list carefully! If you have an idea how to improve the shell detection pull requests are welcome!

--- a/README.md
+++ b/README.md
@@ -16,15 +16,7 @@ echo 'xontrib load sh' >> ~/.xonshrc
 
 ## Usage
 
-There are two ways to invoke an sh-compatible command:
-
-####1. With a shell detected automatically
-
-Start the line with 
-
-`!` ` ` (exclamation mark with space)
-
-then paste the sh-compatible commands after it and run. 
+Start the line with `! ` (exclamation mark with space) then paste the sh-compatible commands after it and run. 
 The commands syntax will be tested in the shells from list (if installed) and the commands will be run in 
 the first matching shell. By default list of shells contains bash and sh. 
 
@@ -35,26 +27,10 @@ To set the list of shells use environment variable before loading the xontrib:
 ```python
 $XONTRIB_SH_SHELLS = ['bash', 'sh']  # default
 xontrib load sh
+! echo hello
 ```
 
-####2. With a shell specified manually
-
-Same as above, but add the required shell name between the exclamation mark and space, either:
-
-`!bash` ` ` the full shell name OR
-
-`!b` ` ` only its first letter
-
-then paste sh-compatible commands after it and run.
-
-Each shell name (or only its first letter, or both, depending on the value of the two environment variables listed below) from the configured list will be matched against the full/short name specified in the prefix, and the commands will be run in the first matching shell (if installed).
-
-```python
-# Given '!b ', match 'b' to the first letter of each shell in $XONTRIB_SH_SHELLS (use the first shell starting with 'b')
-$XONTRIB_SH_USEFIRST = True # default True
-# Given '!bash ', match 'bash' to the full name of each shell in $XONTRIB_SH_SHELLS
-$XONTRIB_SH_USEFULL  = True # default True
-```
+Also you can set the shell explicitly i.e. `!bash ` or `!b ` (the first letter of the shell).
 
 ## The main use case
 
@@ -74,17 +50,16 @@ To run this just start with `! ` or `!b ` or `!bash ` and paste the commands. As
 ### Bash brace expansion
 ```bash
 ! echo 01.{05..10}
-    #OR
-!b echo 01.{05..10}    # unless $XONTRIB_SH_MATCHFIRST = False (default is True)
-    #OR
-!bash echo 01.{05..10} # unless $XONTRIB_SH_MATCHFULL  = False (default is True)
+# Or explicitly:
+!b echo 01.{05..10}
+!bash echo 01.{05..10}
 ``` 
 ```
 bash:
 01.05 01.06 01.07 01.08 01.09 01.10
 ```
 
-### Loop
+### Multiline loop
 ```bash
 ! for i in 1 2 3
 do
@@ -121,22 +96,19 @@ As result the command will be failed:
 $XONTRIB_SH_SHELLS = ['bash', 'fish']
 xontrib load sh
 # Run fish command:
-! set -U EDITOR vim
+! set -U var1 value1
 # bash: line 0: set: -U: invalid option
 ```
-However, the command with the fish shell __specified explicitly__ will succeed
-```python
-# Run fish command in a manually set fish shell
-# requires option '$XONTRIB_SH_MATCHFULL = True', which is the default value
-!fish set -U EDITOR vim
-```
-
-Use shells list carefully! If you have an idea how to improve the shell detection pull requests are welcome!
+To avoid this use the explicit setting the shell i.e. `!fish set -U var1 value1`.
 
 #### Why it's better than [xonsh subprocess macros](https://xon.sh/tutorial_macros.html#subprocess-macros)?
 
 Xonsh subprocess macros is not supporting multiline commands and require more keystrokes.
 
+## Additional options
+
+* `$XONTRIB_SH_USEFULL` (default `True`) - enables to set the shell explicitly by the name of the shell i.e. `!bash `.
+* `$XONTRIB_SH_USEFIRST` (default `True`) - enables to set the shell explicitly by the first letter i.e. `!b ` instead of `!bash `.
 
 ## Links 
 * This package is the part of [ergopack](https://github.com/anki-code/xontrib-ergopack) - the pack of ergonomic xontribs.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Paste and run commands from bash, zsh, fish in xonsh shell.",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     packages=['xontrib'],
     package_dir={'xontrib': 'xontrib'},
     package_data={'xontrib': ['*.py']},

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (IOError, OSError):
 
 setup(
     name='xontrib-sh',
-    version='0.1.2',
+    version='0.2.0',
     license='BSD',
     author='anki',
     author_email='author@example.com',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Paste and run commands from bash, zsh, fish in xonsh shell.",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    python_requires='>=3.8',
+    python_requires='>=3.6',
     packages=['xontrib'],
     package_dir={'xontrib': 'xontrib'},
     package_data={'xontrib': ['*.py']},

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -15,6 +15,10 @@ def onepath(cmd, **kw):
                 if exists := which(s):
                     if not exists.lower().endswith(_bash_win):
                         _installed_shells.append(s)
+        if not _installed_shells:
+            ret_val = "xontrib-sh: No known shell is installed: " \
+                + ", ".join(map(str, _shells))
+            return f'echo @({repr(ret_val)})'
 
         shell_cmd = cmd[1:].strip()
 
@@ -59,6 +63,10 @@ def onepath(cmd, **kw):
         if first_compatible_shell:
             return f'{first_compatible_shell} -c @({repr(shell_cmd)})'
         else:
-            return f'echo @({repr("")})'
+            ret_val = "xontrib-sh: '" + cmd[1:cmd.find(" ")] + "'" \
+                + " is not matching any known shell" \
+                + " (or a matching shell isn't installed): " \
+                + ", ".join(map(str, _shells))
+            return f'echo @({repr(ret_val)})'
 
     return cmd

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -1,7 +1,7 @@
 from shutil import which
 
 _shells = list(__xonsh__.env.get('XONTRIB_SH_SHELLS', ['bash', 'sh']))
-_bash_wsl = 'c:\\windows\\system32\\bash.EXE'
+_bash_win = 'bash.exe'
 _installed_shells = []
 _match_first_char = __xonsh__.env.get('XONTRIB_SH_MATCHFIRST', True)
 _match_full_name = __xonsh__.env.get('XONTRIB_SH_MATCHFULL', True)
@@ -12,9 +12,9 @@ def onepath(cmd, **kw):
     if len(cmd) > 2 and cmd.startswith('! '):
         if not _installed_shells:
             for s in _shells:
-                exists = which(s)
-                if exists and (exists != _bash_wsl):
-                    _installed_shells.append(s)
+                if exists := which(s):
+                    if not exists.lower().endswith(_bash_win):
+                        _installed_shells.append(s)
 
         shell_cmd = cmd[1:].strip()
 
@@ -39,16 +39,16 @@ def onepath(cmd, **kw):
         if _match_first_char:
             for shell in _shells:
                 if cmd.startswith('!' + shell[0] + ' '):
-                    exists = which(shell)
-                    if exists and (exists != _bash_wsl):
-                        first_compatible_shell = shell
+                    if exists := which(shell):
+                        if not exists.lower().endswith(_bash_win):
+                            first_compatible_shell = shell
                     break
         if _match_full_name:
             for shell in _shells:
                 if cmd.startswith('!' + shell + ' '):
-                    exists = which(shell)
-                    if exists and (exists != _bash_wsl):
-                        first_compatible_shell = shell
+                    if exists := which(shell):
+                        if not exists.lower().endswith(_bash_win):
+                            first_compatible_shell = shell
                     break
 
         shell_cmd = cmd[cmd.find(' '):].strip()

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -1,6 +1,7 @@
 from shutil import which
 
 _shells = list(__xonsh__.env.get('XONTRIB_SH_SHELLS', ['bash', 'sh']))
+_bash_wsl = 'c:\\windows\\system32\\bash.EXE'
 _installed_shells = []
 _match_first_char = __xonsh__.env.get('XONTRIB_SH_MATCHFIRST', True)
 _match_full_name = __xonsh__.env.get('XONTRIB_SH_MATCHFULL', True)
@@ -11,7 +12,8 @@ def onepath(cmd, **kw):
     if len(cmd) > 2 and cmd.startswith('! '):
         if not _installed_shells:
             for s in _shells:
-                if which(s):
+                exists = which(s)
+                if exists and (exists != _bash_wsl):
                     _installed_shells.append(s)
 
         shell_cmd = cmd[1:].strip()
@@ -37,13 +39,15 @@ def onepath(cmd, **kw):
         if _match_first_char:
             for shell in _shells:
                 if cmd.startswith('!' + shell[0] + ' '):
-                    if which(shell):
+                    exists = which(shell)
+                    if exists and (exists != _bash_wsl):
                         first_compatible_shell = shell
                     break
         if _match_full_name:
             for shell in _shells:
                 if cmd.startswith('!' + shell + ' '):
-                    if which(shell):
+                    exists = which(shell)
+                    if exists and (exists != _bash_wsl):
                         first_compatible_shell = shell
                     break
 

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -2,6 +2,9 @@ from shutil import which
 
 _shells = list(__xonsh__.env.get('XONTRIB_SH_SHELLS', ['bash', 'sh']))
 _installed_shells = []
+_match_first_char = __xonsh__.env.get('XONTRIB_SH_MATCHFIRST', True)
+_match_full_name = __xonsh__.env.get('XONTRIB_SH_MATCHFULL', True)
+
 
 @events.on_transform_command
 def onepath(cmd, **kw):
@@ -29,4 +32,29 @@ def onepath(cmd, **kw):
             return f'{first_compatible_shell} -c @({repr(shell_cmd)})'
         else:
             return f'echo @({repr(check_output_all.lstrip())})'
+    elif len(cmd) > 3 and cmd.startswith('!'):
+        first_compatible_shell = None
+        if _match_first_char:
+            for shell in _shells:
+                if cmd.startswith('!' + shell[0] + ' '):
+                    if which(shell):
+                        first_compatible_shell = shell
+                    break
+        if _match_full_name:
+            for shell in _shells:
+                if cmd.startswith('!' + shell + ' '):
+                    if which(shell):
+                        first_compatible_shell = shell
+                    break
+
+        shell_cmd = cmd[cmd.find(' '):].strip()
+
+        if not shell_cmd:
+            return cmd
+
+        if first_compatible_shell:
+            return f'{first_compatible_shell} -c @({repr(shell_cmd)})'
+        else:
+            return f'echo @({repr("")})'
+
     return cmd

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -12,7 +12,8 @@ def onepath(cmd, **kw):
     if len(cmd) > 2 and cmd.startswith('! '):
         if not _installed_shells:
             for s in _shells:
-                if exists := which(s):
+                exists = which(s)
+                if exists:
                     if not exists.lower().endswith(_bash_win):
                         _installed_shells.append(s)
         if not _installed_shells:
@@ -43,14 +44,16 @@ def onepath(cmd, **kw):
         if _match_first_char:
             for shell in _shells:
                 if cmd.startswith('!' + shell[0] + ' '):
-                    if exists := which(shell):
+                    exists = which(shell)
+                    if exists:
                         if not exists.lower().endswith(_bash_win):
                             first_compatible_shell = shell
                     break
         if _match_full_name:
             for shell in _shells:
                 if cmd.startswith('!' + shell + ' '):
-                    if exists := which(shell):
+                    exists = which(shell)
+                    if exists:
                         if not exists.lower().endswith(_bash_win):
                             first_compatible_shell = shell
                     break


### PR DESCRIPTION
I've added one feature:
1. Custom shell name can be manually specified, e.g. `!bash <cmd>` or `!b <cmd>` instead of being auto-detected with `! <cmd>`. Each matching option (full name or first letter) is configured via a separate environmental variable (`$XONTRIB_SH_MATCHFULL` or `$XONTRIB_SH_MATCHFIRST`), both enabled by default

and removed the other feature originally submitted from this PR, let me know if you reconsider this WSL support.
By the way, I've also excluded the WSL bash from matching when a user is outside a WSL instance


2. Can run a WSL shell (rather useful on Windows) with, e.g. `!fw <cmd>` for fish in WSL (if it's included in the list of shells)

Only tested this on Windows with bash/fish/pwsh on xonsh/0.9.26, but seems to be working fine :)