### PR TITLE
Improve handling of pwsh and cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ xontrib load sh
 ```
 To avoid this use the explicit setting the shell i.e. `!fish set -U var1 value1`.
 
+Also, since __pwsh__ and __cmd__ shells don't have an option to detect their own syntax, they can only be invoked:
+
+  - explicitly by their name, i.e. `!p ` or `!pwsh `
+  - implicitly via the `! ` prefix only when there is __one__ shell in `$XONTRIB_SH_SHELLS`
+
 #### Why it's better than [xonsh subprocess macros](https://xon.sh/tutorial_macros.html#subprocess-macros)?
 
 Xonsh subprocess macros is not supporting multiline commands and require more keystrokes.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='BSD',
     author='anki',
     author_email='author@example.com',
-    description="Paste and run commands from bash, zsh, fish in xonsh shell.",
+    description="Paste and run commands from bash, zsh, fish, tcsh, pwsh, cmd in xonsh shell.",
     long_description=long_description,
     long_description_content_type='text/markdown',
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (IOError, OSError):
 
 setup(
     name='xontrib-sh',
-    version='0.2.1',
+    version='0.3.0',
     license='BSD',
     author='anki',
     author_email='author@example.com',

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -10,6 +10,8 @@ _shells_without_syntax_check = ['pwsh', 'powershell', 'cmd']
 
 @events.on_transform_command
 def onepath(cmd, **kw):
+    cmd_flag = '-c' # *sh flag to execute the specified commands, change to '/C' for cmd
+
     if len(cmd) > 2 and cmd.startswith('! '):
         if not _installed_shells:
             for s in _shells:
@@ -30,7 +32,9 @@ def onepath(cmd, **kw):
         first_compatible_shell = None
         check_output_all = ''
         if len(_shells) == 1:   # skip syntax check for a single shell
-            return f'{_installed_shells[0]} -c @({repr(shell_cmd)})'
+            if _installed_shells[0] == 'cmd':
+                cmd_flag = '/C'
+            return f'{_installed_shells[0]} {cmd_flag} @({repr(shell_cmd)})'
         for s in _installed_shells:
             if s in _shells_without_syntax_check:  # skip shells that don't have a syntax check
                 continue
@@ -41,7 +45,7 @@ def onepath(cmd, **kw):
             check_output_all += f'\n\n{s}:\n\n{check_output}'
 
         if first_compatible_shell:
-            return f'{first_compatible_shell} -c @({repr(shell_cmd)})'
+            return f'{first_compatible_shell} {cmd_flag} @({repr(shell_cmd)})'
         else:
             return f'echo @({repr(check_output_all.lstrip())})'
     elif len(cmd) > 3 and cmd.startswith('!')\
@@ -71,7 +75,9 @@ def onepath(cmd, **kw):
             return cmd
 
         if first_compatible_shell:
-            return f'{first_compatible_shell} -c @({repr(shell_cmd)})'
+            if first_compatible_shell == 'cmd':
+                cmd_flag = '/C'
+            return f'{first_compatible_shell} {cmd_flag} @({repr(shell_cmd)})'
         else:
             ret_val = "xontrib-sh: '" + cmd[1:cmd.find(" ")] + "'" \
                 + " is not matching any known shell" \

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -5,6 +5,7 @@ _bash_win = 'bash.exe'
 _installed_shells = []
 _match_first_char = __xonsh__.env.get('XONTRIB_SH_MATCHFIRST', True)
 _match_full_name = __xonsh__.env.get('XONTRIB_SH_MATCHFULL', True)
+_shells_without_syntax_check = ['pwsh', 'powershell', 'cmd']
 
 
 @events.on_transform_command
@@ -28,7 +29,11 @@ def onepath(cmd, **kw):
 
         first_compatible_shell = None
         check_output_all = ''
+        if len(_shells) == 1:   # skip syntax check for a single shell
+            return f'{_installed_shells[0]} -c @({repr(shell_cmd)})'
         for s in _installed_shells:
+            if s in _shells_without_syntax_check:  # skip shells that don't have a syntax check
+                continue
             check_output = __xonsh__.subproc_captured_stdout([s, '-nc', shell_cmd, '2>&1']).strip()
             if check_output == '':
                 first_compatible_shell = s

--- a/xontrib/sh.py
+++ b/xontrib/sh.py
@@ -15,7 +15,7 @@ def onepath(cmd, **kw):
                 exists = which(s)
                 if exists:
                     if not exists.lower().endswith(_bash_win):
-                        _installed_shells.append(s)
+                        _installed_shells.append(s.rstrip('.exe').lower())
         if not _installed_shells:
             ret_val = "xontrib-sh: No known shell is installed: " \
                 + ", ".join(map(str, _shells))


### PR DESCRIPTION
- disabled shell syntax check when it can't be or doesn't need to be done (closes https://github.com/anki-code/xontrib-sh/issues/3)
- add proper use of `cmd` with `/c` so that it doesn't persist (instead of `-c`)

Also, you might want to add `pwsh, cmd` to your project description